### PR TITLE
Adding adding optional parameters to search and retrieve functions 

### DIFF
--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -1628,7 +1628,8 @@ class DICOMwebClient:
         offset: Optional[int] = None,
         fields: Optional[Sequence[str]] = None,
         search_filters: Optional[Dict[str, Any]] = None,
-        get_remaining: bool = False
+        get_remaining: bool = False,
+        additional_params: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, dict]]:
         """Search for studies.
 
@@ -1649,6 +1650,8 @@ class DICOMwebClient:
         get_remaining: bool, optional
             Whether remaining results should be included (this may repeatedly
             query the server for remaining results)
+        additional_params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters to include in the request.
 
         Returns
         -------
@@ -1656,12 +1659,14 @@ class DICOMwebClient:
             Study representations
             (see `Study Result Attributes <http://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_6.7.html#table_6.7.1-2>`_)
 
-        Note
+        Notes
         ----
-        The server may only return a subset of search results. In this case,
+        - The server may only return a subset of search results. In this case,
         a warning will notify the client that there are remaining results.
         Remaining results can be requested via repeated calls using the
         `offset` parameter.
+        - If `additional_params` is provided, it will be merged into the standard query parameters,
+        with its values overwriting any existing keys if duplicates are present.
 
         """  # noqa: E501: E501
         logger.info('search for studies')
@@ -1673,6 +1678,8 @@ class DICOMwebClient:
             fields=fields,
             search_filters=search_filters
         )
+        if additional_params:
+            params.update(additional_params)
         return self._http_get_application_json(
             url,
             params=params,
@@ -1918,7 +1925,8 @@ class DICOMwebClient:
         self,
         study_instance_uid: str,
         media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
-        stream: bool = False
+        stream: bool = False,
+        params: Optional[Dict[str, Any]] = None
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Get all instances of a study.
 
@@ -1932,6 +1940,8 @@ class DICOMwebClient:
         stream: bool, optional
             Whether data should be streamed (i.e., requested using chunked
             transfer encoding)
+        params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -1947,6 +1957,7 @@ class DICOMwebClient:
         if media_types is None:
             return self._http_get_multipart_application_dicom(
                 url,
+                params=params,
                 stream=stream
             )
         common_media_types = self._get_common_media_types(media_types)
@@ -1964,6 +1975,7 @@ class DICOMwebClient:
         return self._http_get_multipart_application_dicom(
             url,
             media_types=media_types,
+            params=params,
             stream=stream
         )
 
@@ -2129,7 +2141,8 @@ class DICOMwebClient:
         offset: Optional[int] = None,
         fields: Optional[Sequence[str]] = None,
         search_filters: Optional[Dict[str, Any]] = None,
-        get_remaining: bool = False
+        get_remaining: bool = False,
+        additional_params: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, dict]]:
         """Search for series.
 
@@ -2152,6 +2165,8 @@ class DICOMwebClient:
         get_remaining: bool, optional
             Whether remaining results should be included (this may repeatedly
             query the server for remaining results)
+        additional_params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters to include in the request.
 
         Returns
         -------
@@ -2159,12 +2174,14 @@ class DICOMwebClient:
             Series representations
             (see `Series Result Attributes <http://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_6.7.html#table_6.7.1-2a>`_)
 
-        Note
+        Notes
         ----
-        The server may only return a subset of search results. In this case,
+        - The server may only return a subset of search results. In this case,
         a warning will notify the client that there are remaining results.
         Remaining results can be requested via repeated calls using the
         `offset` parameter.
+        - If `additional_params` is provided, it will be merged into the standard query parameters,
+        with its values overwriting any existing keys if duplicates are present.
 
         """  # noqa: E501
         if study_instance_uid is not None:
@@ -2180,6 +2197,8 @@ class DICOMwebClient:
             fields=fields,
             search_filters=search_filters
         )
+        if additional_params:
+            params.update(additional_params)
         return self._http_get_application_json(
             url,
             params=params,
@@ -2191,7 +2210,8 @@ class DICOMwebClient:
         study_instance_uid: str,
         series_instance_uid: str,
         media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
-        stream: bool = False
+        stream: bool = False,
+        params: Optional[Dict[str, Any]] = None
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Get instances of a series.
 
@@ -2207,6 +2227,8 @@ class DICOMwebClient:
         stream: bool, optional
             Whether data should be streamed (i.e., requested using chunked
             transfer encoding)
+        params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -2236,6 +2258,7 @@ class DICOMwebClient:
         if media_types is None:
             return self._http_get_multipart_application_dicom(
                 url,
+                params=params,
                 stream=stream
             )
         common_media_types = self._get_common_media_types(media_types)
@@ -2253,6 +2276,7 @@ class DICOMwebClient:
         return self._http_get_multipart_application_dicom(
             url,
             media_types=media_types,
+            params=params,
             stream=stream
         )
 
@@ -2514,7 +2538,8 @@ class DICOMwebClient:
         offset: Optional[int] = None,
         fields: Optional[Sequence[str]] = None,
         search_filters: Optional[Dict[str, Any]] = None,
-        get_remaining: bool = False
+        get_remaining: bool = False,
+        additional_params: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, dict]]:
         """Search for instances.
 
@@ -2539,6 +2564,8 @@ class DICOMwebClient:
         get_remaining: bool, optional
             Whether remaining results should be included (this may repeatedly
             query the server for remaining results)
+        additional_params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters to include in the request.
 
         Returns
         -------
@@ -2548,10 +2575,12 @@ class DICOMwebClient:
 
         Note
         ----
-        The server may only return a subset of search results. In this case,
+        - The server may only return a subset of search results. In this case,
         a warning will notify the client that there are remaining results.
         Remaining results can be requested via repeated calls using the
         `offset` parameter.
+        - If `additional_params` is provided, it will be merged into the standard query parameters,
+        with its values overwriting any existing keys if duplicates are present.
 
         """  # noqa: E501
         message = 'search for instances'
@@ -2585,6 +2614,7 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
+        params: Optional[Dict[str, Any]] = None
     ) -> pydicom.dataset.Dataset:
         """Retrieve an individual instance.
 
@@ -2599,6 +2629,8 @@ class DICOMwebClient:
         media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
+        params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -2657,7 +2689,11 @@ class DICOMwebClient:
                 f'Media type "{common_media_type}" is not supported for '
                 'retrieval of an instance. It must be "application/dicom".'
             )
-        iterator = self._http_get_multipart_application_dicom(url, media_types)
+        iterator = self._http_get_multipart_application_dicom(
+            url,
+            media_types=media_types,
+            params=params
+        )
         instances = list(iterator)
         if len(instances) > 1:
             # This should not occur, but safety first.

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -2101,7 +2101,7 @@ class DICOMwebClient:
         study_instance_uid: str
             Study Instance UID
         additional_params: Union[Dict[str, Any], None], optional
-            Additional HTTP GET query parameters 
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -3013,10 +3013,10 @@ class DICOMwebClient:
         url += f'/frames/{frame_list}'
         if media_types is None:
             return self._http_get_multipart(
-                url, 
+                url,
                 stream=stream,
                 params=additional_params
-                )
+            )
 
         common_media_types = self._get_common_media_types(media_types)
         if len(common_media_types) > 1:

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -3068,7 +3068,8 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
+        additional_params: Optional[Dict[str, Any]] = None
     ) -> List[bytes]:
         """Retrieve one or more frames of an image instance.
 
@@ -3085,6 +3086,8 @@ class DICOMwebClient:
         media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
+        additional_params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -3099,7 +3102,8 @@ class DICOMwebClient:
                 sop_instance_uid=sop_instance_uid,
                 frame_numbers=frame_numbers,
                 media_types=media_types,
-                stream=False
+                stream=False,
+                additional_params=additional_params
             )
         )
 
@@ -3109,7 +3113,8 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
+        additional_params: Optional[Dict[str, Any]] = None
     ) -> Iterator[bytes]:
         """Iterate over frames of an image instance.
 
@@ -3126,6 +3131,8 @@ class DICOMwebClient:
         media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
+        additional_params: Union[Dict[str, Any], None], optional
+            Additional HTTP GET query parameters
 
         Returns
         -------
@@ -3143,7 +3150,8 @@ class DICOMwebClient:
             sop_instance_uid=sop_instance_uid,
             frame_numbers=frame_numbers,
             media_types=media_types,
-            stream=True
+            stream=True,
+            additional_params=additional_params
         )
 
     def retrieve_instance_frames_rendered(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,5 @@
 import json
+from operator import add
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from http import HTTPStatus
@@ -136,6 +137,24 @@ def test_search_for_studies(httpserver, client, cache_dir):
     )
 
 
+def test_search_for_studies_with_additional_params(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('search_for_studies.json'))
+    with open(cache_filename, 'r') as f:
+        content = f.read()
+    parsed_content = json.loads(content)
+    headers = {'content-type': 'application/dicom+json'}
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    assert client.search_for_studies(additional_params=params) == parsed_content
+    request = httpserver.requests[0]
+    assert request.path == '/studies'
+    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert all(
+        mime[0] in ('application/json', 'application/dicom+json')
+        for mime in request.accept_mimetypes
+    )
+
+
 def test_search_for_studies_with_retries(httpserver, client, cache_dir):
     headers = {'content-type': 'application/dicom+json'}
     max_attempts = 3
@@ -217,6 +236,24 @@ def test_search_for_series(httpserver, client, cache_dir):
     )
 
 
+def test_search_for_series_with_additional_params(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('search_for_series.json'))
+    with open(cache_filename, 'r') as f:
+        content = f.read()
+    parsed_content = json.loads(content)
+    headers = {'content-type': 'application/dicom+json'}
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    assert client.search_for_series(additional_params=params) == parsed_content
+    request = httpserver.requests[0]
+    assert request.path == '/series'
+    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert all(
+        mime[0] in ('application/json', 'application/dicom+json')
+        for mime in request.accept_mimetypes
+    )
+
+
 def test_search_for_series_filter_modality(httpserver, client, cache_dir):
     cache_filename = str(cache_dir.joinpath('search_for_series.json'))
     with open(cache_filename, 'r') as f:
@@ -282,6 +319,24 @@ def test_search_for_instances(httpserver, client, cache_dir):
     assert client.search_for_instances() == parsed_content
     request = httpserver.requests[0]
     assert request.path == '/instances'
+    assert all(
+        mime[0] in ('application/json', 'application/dicom+json')
+        for mime in request.accept_mimetypes
+    )
+
+
+def test_search_for_instances_with_additional_params(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('search_for_instances.json'))
+    with open(cache_filename, 'r') as f:
+        content = f.read()
+    parsed_content = json.loads(content)
+    headers = {'content-type': 'application/dicom+json'}
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    assert client.search_for_instances(additional_params=params) == parsed_content
+    request = httpserver.requests[0]
+    assert request.path == '/instances'
+    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
     assert all(
         mime[0] in ('application/json', 'application/dicom+json')
         for mime in request.accept_mimetypes
@@ -368,6 +423,35 @@ def test_retrieve_instance_metadata(httpserver, client, cache_dir):
     )
     assert result == parsed_content[0]
     request = httpserver.requests[0]
+    expected_path = (
+        f'/studies/{study_instance_uid}'
+        f'/series/{series_instance_uid}'
+        f'/instances/{sop_instance_uid}/metadata'
+    )
+    assert request.path == expected_path
+    assert all(
+        mime[0] in ('application/json', 'application/dicom+json')
+        for mime in request.accept_mimetypes
+    )
+
+
+def test_retrieve_instance_metadata_with_additional_params(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('retrieve_instance_metadata.json'))
+    with open(cache_filename, 'r') as f:
+        content = f.read()
+    parsed_content = json.loads(content)
+    headers = {'content-type': 'application/dicom+json'}
+    httpserver.serve_content(content=content, code=200, headers=headers)
+    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    study_instance_uid = '1.2.3'
+    series_instance_uid = '1.2.4'
+    sop_instance_uid = '1.2.5'
+    result = client.retrieve_instance_metadata(
+        study_instance_uid, series_instance_uid, sop_instance_uid, additional_params=params
+    )
+    assert result == parsed_content[0]
+    request = httpserver.requests[0]
+    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
     expected_path = (
         f'/studies/{study_instance_uid}'
         f'/series/{series_instance_uid}'
@@ -511,6 +595,45 @@ def test_retrieve_instance(httpserver, client, cache_dir):
         raw_result = fp.getvalue()
     assert raw_result == data
     request = httpserver.requests[0]
+    expected_path = (
+        f'/studies/{study_instance_uid}'
+        f'/series/{series_instance_uid}'
+        f'/instances/{sop_instance_uid}'
+    )
+    assert request.path == expected_path
+    assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
+
+def test_retrieve_instance_with_additional_params(httpserver, client, cache_dir):
+    cache_filename = str(cache_dir.joinpath('file.dcm'))
+    with open(cache_filename, 'rb') as f:
+        data = f.read()
+    media_type = 'application/dicom'
+    boundary = 'boundary'
+    headers = {
+        'content-type': (
+            'multipart/related; '
+            f'type="{media_type}"; '
+            f'boundary="{boundary}"'
+        ),
+    }
+    message = DICOMwebClient._encode_multipart_message(
+        content=[data],
+        content_type=headers['content-type']
+    )
+    httpserver.serve_content(content=message, code=200, headers=headers)
+    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    study_instance_uid = '1.2.3'
+    series_instance_uid = '1.2.4'
+    sop_instance_uid = '1.2.5'
+    response = client.retrieve_instance(
+        study_instance_uid, series_instance_uid, sop_instance_uid, additional_params=params
+    )
+    with BytesIO() as fp:
+        pydicom.dcmwrite(fp, response)
+        raw_result = fp.getvalue()
+    assert raw_result == data
+    request = httpserver.requests[0]
+    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
     expected_path = (
         f'/studies/{study_instance_uid}'
         f'/series/{series_instance_uid}'

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,4 @@
 import json
-from operator import add
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from http import HTTPStatus
@@ -137,18 +136,24 @@ def test_search_for_studies(httpserver, client, cache_dir):
     )
 
 
-def test_search_for_studies_with_additional_params(httpserver, client, cache_dir):
+def test_search_for_studies_with_additional_params(
+        httpserver,
+        client,
+        cache_dir
+):
     cache_filename = str(cache_dir.joinpath('search_for_studies.json'))
     with open(cache_filename, 'r') as f:
         content = f.read()
     parsed_content = json.loads(content)
     headers = {'content-type': 'application/dicom+json'}
     httpserver.serve_content(content=content, code=200, headers=headers)
-    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    params = {"key1": ["value1", "value2"], "key2": "value3"}
     assert client.search_for_studies(additional_params=params) == parsed_content
     request = httpserver.requests[0]
     assert request.path == '/studies'
-    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert request.query_string.decode() == (
+        'key1=value1&key1=value2&key2=value3'
+    )
     assert all(
         mime[0] in ('application/json', 'application/dicom+json')
         for mime in request.accept_mimetypes
@@ -236,18 +241,24 @@ def test_search_for_series(httpserver, client, cache_dir):
     )
 
 
-def test_search_for_series_with_additional_params(httpserver, client, cache_dir):
+def test_search_for_series_with_additional_params(
+        httpserver,
+        client,
+        cache_dir
+):
     cache_filename = str(cache_dir.joinpath('search_for_series.json'))
     with open(cache_filename, 'r') as f:
         content = f.read()
     parsed_content = json.loads(content)
     headers = {'content-type': 'application/dicom+json'}
     httpserver.serve_content(content=content, code=200, headers=headers)
-    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    params = {"key1": ["value1", "value2"], "key2": "value3"}
     assert client.search_for_series(additional_params=params) == parsed_content
     request = httpserver.requests[0]
     assert request.path == '/series'
-    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert request.query_string.decode() == (
+        'key1=value1&key1=value2&key2=value3'
+    )
     assert all(
         mime[0] in ('application/json', 'application/dicom+json')
         for mime in request.accept_mimetypes
@@ -325,18 +336,26 @@ def test_search_for_instances(httpserver, client, cache_dir):
     )
 
 
-def test_search_for_instances_with_additional_params(httpserver, client, cache_dir):
+def test_search_for_instances_with_additional_params(
+        httpserver,
+        client,
+        cache_dir
+):
     cache_filename = str(cache_dir.joinpath('search_for_instances.json'))
     with open(cache_filename, 'r') as f:
         content = f.read()
     parsed_content = json.loads(content)
     headers = {'content-type': 'application/dicom+json'}
     httpserver.serve_content(content=content, code=200, headers=headers)
-    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
-    assert client.search_for_instances(additional_params=params) == parsed_content
+    params = {"key1": ["value1", "value2"], "key2": "value3"}
+    assert client.search_for_instances(
+        additional_params=params
+    ) == parsed_content
     request = httpserver.requests[0]
     assert request.path == '/instances'
-    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert request.query_string.decode() == (
+        'key1=value1&key1=value2&key2=value3'
+    )
     assert all(
         mime[0] in ('application/json', 'application/dicom+json')
         for mime in request.accept_mimetypes
@@ -435,23 +454,32 @@ def test_retrieve_instance_metadata(httpserver, client, cache_dir):
     )
 
 
-def test_retrieve_instance_metadata_with_additional_params(httpserver, client, cache_dir):
+def test_retrieve_instance_metadata_with_additional_params(
+        httpserver,
+        client,
+        cache_dir
+):
     cache_filename = str(cache_dir.joinpath('retrieve_instance_metadata.json'))
     with open(cache_filename, 'r') as f:
         content = f.read()
     parsed_content = json.loads(content)
     headers = {'content-type': 'application/dicom+json'}
     httpserver.serve_content(content=content, code=200, headers=headers)
-    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    params = {"key1": ["value1", "value2"], "key2": "value3"}
     study_instance_uid = '1.2.3'
     series_instance_uid = '1.2.4'
     sop_instance_uid = '1.2.5'
     result = client.retrieve_instance_metadata(
-        study_instance_uid, series_instance_uid, sop_instance_uid, additional_params=params
+        study_instance_uid,
+        series_instance_uid,
+        sop_instance_uid,
+        additional_params=params
     )
     assert result == parsed_content[0]
     request = httpserver.requests[0]
-    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert request.query_string.decode() == (
+        'key1=value1&key1=value2&key2=value3'
+    )
     expected_path = (
         f'/studies/{study_instance_uid}'
         f'/series/{series_instance_uid}'
@@ -603,7 +631,12 @@ def test_retrieve_instance(httpserver, client, cache_dir):
     assert request.path == expected_path
     assert request.accept_mimetypes[0][0][:43] == headers['content-type'][:43]
 
-def test_retrieve_instance_with_additional_params(httpserver, client, cache_dir):
+
+def test_retrieve_instance_with_additional_params(
+        httpserver,
+        client,
+        cache_dir
+):
     cache_filename = str(cache_dir.joinpath('file.dcm'))
     with open(cache_filename, 'rb') as f:
         data = f.read()
@@ -621,19 +654,24 @@ def test_retrieve_instance_with_additional_params(httpserver, client, cache_dir)
         content_type=headers['content-type']
     )
     httpserver.serve_content(content=message, code=200, headers=headers)
-    params = {"key1" : ["value1", "value2"], "key2" : "value3"}
+    params = {"key1": ["value1", "value2"], "key2": "value3"}
     study_instance_uid = '1.2.3'
     series_instance_uid = '1.2.4'
     sop_instance_uid = '1.2.5'
     response = client.retrieve_instance(
-        study_instance_uid, series_instance_uid, sop_instance_uid, additional_params=params
+        study_instance_uid,
+        series_instance_uid,
+        sop_instance_uid,
+        additional_params=params
     )
     with BytesIO() as fp:
         pydicom.dcmwrite(fp, response)
         raw_result = fp.getvalue()
     assert raw_result == data
     request = httpserver.requests[0]
-    assert request.query_string.decode() == 'key1=value1&key1=value2&key2=value3'
+    assert request.query_string.decode() == (
+        'key1=value1&key1=value2&key2=value3'
+    )
     expected_path = (
         f'/studies/{study_instance_uid}'
         f'/series/{series_instance_uid}'


### PR DESCRIPTION
### Change
- Passing an optional parameters to search and retrieve functions in a dict
- These parameters are then being passed to the HTTP requests in ``_http_get_application_json `` and `` _http_get_multipart_application_dicom `` 

### Testing
- ``pytest --flake8``
